### PR TITLE
Add metadata tests (closes #16).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+language: go
+go:
+  - tip
+  - 1.5
+script: 
+  - go get golang.org/x/tools/cmd/vet
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/cloudflare/cfssl_trust/... 
+  - go test -cover github.com/cloudflare/cfssl_trust/... 
+  - go vet github.com/cloudflare/cfssl_trust/... 
+notifications:
+  email:
+    recipients:
+      - kyle@cloudflare.com
+      - jacob@cloudflare.com
+      - zi@cloudflare.com
+    on_success: change
+    on_failure: change

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+type metadata struct {
+	Name     string `json:"name"`
+	Weight   int    `json:"weight"`
+	HashAlgo string `json:"hash_algo"`
+	KeyAlgo  string `json:"key_algo"`
+	Keystore string `json:"keystore"`
+}
+
+var metadataFiles = []string{
+	"ca-bundle.crt.metadata",
+}
+
+func TestMetadataFormat(t *testing.T) {
+	for _, file := range metadataFiles {
+		in, err := ioutil.ReadFile(file)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		// Ensure the metadata is well-formatted JSON.
+		var ms []metadata
+		err = json.Unmarshal(in, &ms)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
+
+		for _, m := range ms {
+			// Ensure the metadata points to a valid keystore.
+			if m.Keystore != "" {
+				_, err = os.Stat(m.Keystore)
+				if err != nil {
+					t.Fatalf("%v", err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This will verify that the metadata file is properly formatted
JSON, and for each metadata element that lists a keystore,
ensures that keystore is present in the repo.