### PR TITLE
Strip chars from the filename for certs that are not allowed on windows

### DIFF
--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -29,6 +29,9 @@ var directory = new(string)
 // map holds all of the filenames and a count to account for duplicates
 var filenameCount = make(map[string]int)
 
+// characters to strip from the output file name (these are mostly non-permitted windows chars)
+var stripChars = [9]string{"\\", "\"", "/", ":", "*", "?","<",">","|"}
+
 // Parse arguments from the command line.
 // To run the script: "go run format.go -f filename -d directory"
 func parseArgs() int {
@@ -79,6 +82,11 @@ func applyNamingConv(file []byte, filename string) error {
 	filenameCount[name]++
 	if filenameCount[name] > 1 {
 		name += "_" + strconv.Itoa(filenameCount[name])
+	}
+
+	//Strip any invalid chars from the name
+	for _,char := range stripChars {
+		name = strings.Replace(name, char, "_", -1)
 	}
 
 	// Finally, rename the file


### PR DESCRIPTION
This fixes the issue behind  #20 and cloudflare/cfssl#589 where certs exist with chars that cannot be in a windows file name.

I would have re-generated the certs and included that in the PR but when I do:
go run cmd/format/format.go -f ca-bundle.crt -d ca-bundle
and
go run cmd/format/format.go -f int-bundle.crt -d intermediate_ca

I get far fewer crts than actually exist in those folders.   So this will not actually fix the windows problem until someone regenerates those two using the patched format.go to update all the crts.