### PR TITLE
Remove go get vet/cover from travis set up.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@ sudo: false
 language: go
 go:
   - tip
+  - 1.7
   - 1.6
-  - 1.5
 before_script:
   - go get -u github.com/golang/lint/golint
 script: 
-  - go get golang.org/x/tools/cmd/cover
   - go get github.com/cloudflare/cfssl_trust/...
   - go test -cover github.com/cloudflare/cfssl_trust/...
   - go vet github.com/cloudflare/cfssl_trust/...
@@ -16,8 +15,6 @@ notifications:
   email:
     recipients:
       - kyle@cloudflare.com
-      - jacob@cloudflare.com
       - zi@cloudflare.com
-      - shiloh@cloudflare.com
     on_success: change
     on_failure: change

--- a/ubuntu_update.go
+++ b/ubuntu_update.go
@@ -26,7 +26,11 @@ func main() {
 	output, _ := os.Create(packageName)
 	defer output.Close()
 
-	res, _ := http.Get(updateURL + packageName)
+	res, err := http.Get(updateURL + packageName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "GET failed: %s\n", err)
+		os.Exit(1)
+	}
 	defer res.Body.Close()
 
 	n, _ := io.Copy(output, res.Body)


### PR DESCRIPTION
As of Go 1.5, these are now core tools.
