### PR TITLE
handle certs with no org or CN field

### DIFF
--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -65,6 +65,10 @@ func applyNamingConv(file []byte, filename string) error {
 	name := ""
 	// If CommonName field is empty, then use the Organization name instead
 	if len(response.Subject.CommonName) == 0 {
+		if len(response.Subject.Organization) == 0 {
+			fmt.Printf("Failing to rename due to missing CN and Org fields: %s", filename)
+			return nil
+		}
 		name = strings.Replace(response.Subject.Organization[0], " ", "", -1)
 		name = strings.Replace(name, "/", "-", -1)
 	} else {


### PR DESCRIPTION
Steps to repro the issue I hit:

```
git clone git://github.com/cloudflare/cfssl_trust
cd cfssl_trust
cfsslmkbundle -f ca-bundle.crt trusted_roots/
go run cmd/format/format.go -f ca-bundle.crt -d ca-bundle
```

And the error I get:

```
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x20dbe0, 0xc420012130)
    /opt/boxen/homebrew/Cellar/go/1.7.1/libexec/src/runtime/panic.go:500 +0x1a1
main.applyNamingConv(0xc420136100, 0xac0, 0xb00, 0xc4200f3dc8, 0x8, 0xc4200f3dc8, 0x8)
    /Users/akerl/tmp/scratch/cfssl_trust/cmd/format/format.go:68 +0x890
main.main()
    /Users/akerl/tmp/scratch/cfssl_trust/cmd/format/format.go:133 +0x525
exit status 2
```

I chased down the issue to this check; the cert it's failing on appears to source from the windows store, and have no commonname or organization value:

```
❯ cfssl certinfo -cert ./ca-bundle/1160.crt
{
  "subject": {
    "country": "BG",
    "names": [
      "BG"
    ]
  },
  "issuer": {
    "country": "BG",
    "names": [
      "BG"
    ]
  },
  "serial_number": "1922916560873434976",
  "not_before": "2006-03-06T17:33:05Z",
  "not_after": "2026-03-06T17:33:05Z",
  "sigalg": "SHA1WithRSA",
  "authority_key_id": "",
  "subject_key_id": "DD:D4:4E:67:43:3F:D3:EA:62:E8:DA:89:6E:8E:3B:6E:B:BB:95:9F",
  "pem": "-----BEGIN CERTIFICATE-----\nMIIHxDCCBaygAwIBAgIIGq+SbI+Tr2AwDQYJKoZIhvcNAQEFBQAwgZUxgZIwCQYD\nVQQGDAJCRzAVBgNVBAoMDkluZm9Ob3RhcnkgUExDMBUGCgmSJomT8ixkARkWB3Jv\nb3QtY2EwGgYDVQQDDBNJbmZvTm90YXJ5IENTUCBSb290MBoGA1UECwwTSW5mb05v\ndGFyeSBDU1AgUm9vdDAfBgkqhkiG9w0BCQEWEmNzcEBpbmZvbm90YXJ5LmNvbTAi\nGA8yMDA2MDMwNjE3MzMwNVoYDzIwMjYwMzA2MTczMzA1WjCBlTGBkjAJBgNVBAYM\nAkJHMBUGA1UECgwOSW5mb05vdGFyeSBQTEMwFQYKCZImiZPyLGQBGRYHcm9vdC1j\nYTAaBgNVBAMME0luZm9Ob3RhcnkgQ1NQIFJvb3QwGgYDVQQLDBNJbmZvTm90YXJ5\nIENTUCBSb290MB8GCSqGSIb3DQEJARYSY3NwQGluZm9ub3RhcnkuY29tMIICIjAN\nBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAnM2kXh+kfgiCT4B2wSeMRxZgn3Os\nyZF/LRBsO5RJnEIzX5TxgyEJkfeStw84RYuUB0qr/j82NVvR1VI4QkboR8dKUDPI\n5OBztpCauqOIONMrQsBu36ITF/JPuefyId1l+qb9UsJgsstPN72vJ45pazJAU1n1\n8jF2iAZtaJ8wvLeBHI5nY8MFZfcz9lmpq7OKRwsUE8c23SL7+EQ0NUEowIG6TrVx\nE68DqEkKLqSbYXdrHSTSpfEt0Udegv9Ig7AVmEfedvtPTsC/VElmvE8B0Xw6Zf7F\nrHBbxRUbcqV9pls7F8O+wz9dEn9nLXZHDIu/FiO1g3LNgM3ouq9eaDM41JDtbtLp\nVgQkofm+bF7KniMgkiuaDUtN46JIj77tqg6Mvqk4cLkQfzJdgCdaA+DURzMlWnap\ng9mYQO1/dQLv7mGRrDE+gNM0S/DCTjUwSV63Keh9IbD/KnmcNDEZZjMgYRovsILV\nsWdTkA2dKpcobrdmPxp/psSaaJbmZlt6N99adxXg2eN8s7LQ1WjbPh1YH47KmHRj\nv9R9Nmju0C+kKvKIL3fDEj+NqCUsBGlYpsu0OfGI0Kbels5zQkbTo/nx2I6KnW6K\nwFJPRbdw/hx7PQ2W3PmQlm3GGKFCwrbc2SMfl5ObDxn5sLc/JXS9glPsDS9t1j9S\nL9h20CW90Ln1vQ8CAwEAAaOCAhAwggIMMA4GA1UdDwEB/wQEAwIBBjBEBggrBgEF\nBQcBAQQ4MDYwNAYIKwYBBQUHMAGGKGh0dHA6Ly9vY3NwLmluZm9ub3RhcnkuY29t\nL3Jlc3BvbmRlci5jZ2kwVgYIKwYBBQUHAQsESjBIMEYGCCsGAQUFBzAFhjpsZGFw\nOi8vbGRhcC5pbmZvbm90YXJ5LmNvbS9kYz1yb290LWNhLGRjPWluZm9ub3Rhcnks\nZGM9Y29tMIGqBgNVHSAEgaIwgZ8wbwYJKwYBBAGBrQABMGIwOgYIKwYBBQUHAgEW\nLmh0dHA6Ly9yZXBvc2l0b3J5LmluZm9ub3RhcnkuY29tL2Nwcy9xY3BzLmh0bWww\nJAYIKwYBBQUHAgIwGBoWSW5mb05vdGFyeSBDU1AgUm9vdCBDQTAsBgkrBgEEAYGt\nAAAwHzAdBggrBgEFBQcCARYRaHR0cDovL3d3dy5jcmMuYmcwDwYDVR0TAQH/BAUw\nAwEB/zB/BgNVHREEeDB2pHQwcjFwMAsGA1UEEQwEMTAwMDAMBgNVBAcMBVNvZmlh\nMBMGA1UEFAwMKzM1OTI5ODc1NzE3MBsGBlUECmQBAQwRMTMxMjc2ODI3OkJVTFNU\nQVQwIQYJKoZIhvcNAQkIDBQxNiBJdmFuIFZhc292IFN0cmVldDAdBgNVHQ4EFgQU\n3dROZ0M/0+pi6NqJbo47bgu7lZ8wDQYJKoZIhvcNAQEFBQADggIBABib/A3B+HGs\n1MwUtScJwVhKNEDmm2XK4PGLUj2Wfoke3qgV+t2ULoPGNl0bIak2Dlw9SYgMUyFd\nH21JNm+cUOvbZM+Juq9erRREh2LvMHzAlt9wOcs7Ue4r/AgFh1bNMyXggBrgpucN\nQ0wAI0NWog4ZVOKN0Q0WuVpvm3flHKmDiyjx4TJ2X0ewmjbqsm/dhjFY/gZpsMNg\npvvYKNQI3fFuThq9zbesviKHFkmxOADVjEMp5ylrKxJiWapD8LRyiDjWAl8f2iSS\njY18/B99OJBYCx8ctxy7NictWhzHMd20K529R6ExtwkR4s1vp270uKMpj/Ngv6cd\n4E+XJSUKMEnH/no5RNTTZe+IXf/Z7lM5vDpEqDE7JZd7mr/R3Wvi1xJq+zK70diO\n85azj5DqeFjBCtulJb6KAx/lktK8f6Ry5OtWeqn6fLjxoL8m/ko0zyWqZMS7e+0Y\n5Uwsb0Fl7eC7PSx1VW/kFQbFS2yT9g9VzJN1hWEmA9LMlct6ECAnVnq/dVjc9Q2W\n2UoHhNgimxDR1gZuFgcDs69546AXurhDCEKdPDsnzHwR1H4x82ZRAhFyOqPpcr2V\nXaEVf0cTOZWyta728WF0MHjHZgHTsnCXCMkNJPREKnCmnS8SZAZuio0g437a8VS/\nDRSsKb59f3+5a0UCUWcVWaIOISfJgmcx\n-----END CERTIFICATE-----\n"
}
```
