### PR TITLE
Add the 'info' command.

### DIFF
--- a/cli/info.go
+++ b/cli/info.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	"github.com/cloudflare/cfssl_trust/info"
+	"github.com/cloudflare/cfssl_trust/model/certdb"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Display information about a certificate.",
+	Long:  "Display information about a certificate give its SKI.",
+	Run:   showInfo,
+}
+
+func init() {
+	RootCmd.AddCommand(infoCmd)
+}
+
+func showInfoForCertificates(db *sql.DB, certs []*certdb.Certificate) error {
+	for _, cert := range certs {
+		err := info.WriteCertificateInformation(os.Stdout, db, cert)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func showInfo(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		os.Exit(0)
+	}
+
+	dbPath := viper.GetString("database.path")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] %s\n", err)
+		os.Exit(1)
+	}
+
+	for _, ski := range args {
+		certs, err := certdb.FindCertificateBySKI(db, ski)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[!] %s\n", err)
+			os.Exit(1)
+		}
+
+		err = showInfoForCertificates(db, certs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[!] %s\n", err)
+			os.Exit(1)
+		}
+	}
+}

--- a/info/info.go
+++ b/info/info.go
@@ -1,0 +1,68 @@
+package info
+
+import (
+	"crypto/x509"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/cloudflare/cfssl_trust/model/certdb"
+)
+
+func writeBasicInformation(w io.Writer, cert *x509.Certificate) error {
+	_, err := fmt.Fprintf(w, `Subject: %s
+Issuer: %s
+	Not Before: %s
+	Not After: %s
+`, displayName(cert.Subject), displayName(cert.Issuer),
+		cert.NotBefore.Format(dateFormat),
+		cert.NotAfter.Format(dateFormat),
+	)
+	return err
+}
+
+func writeCertificateReleases(w io.Writer, tx *sql.Tx, cert *certdb.Certificate) error {
+	releases, err := cert.Releases(tx)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(w, "Releases:\n")
+	if err != nil {
+		return err
+	}
+
+	for _, rel := range releases {
+		_, err = fmt.Fprintf(w, "\t- %s %s (%s)\n",
+			rel.Version, rel.Bundle,
+			time.Unix(rel.ReleasedAt, 0).Format(dateFormat))
+		if err != nil {
+			break
+		}
+	}
+
+	return err
+}
+
+func WriteCertificateInformation(w io.Writer, db *sql.DB, cert *certdb.Certificate) error {
+	tx, err := db.Begin()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] %s\n", err)
+		os.Exit(1)
+	}
+	defer certdb.Finalize(&err, tx)
+
+	err = writeBasicInformation(w, cert.X509())
+	if err != nil {
+		return err
+	}
+
+	err = writeCertificateReleases(w, tx, cert)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/info/info_test.go
+++ b/info/info_test.go
@@ -1,0 +1,123 @@
+package info
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/cfssl_trust/model/certdb"
+
+	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+var (
+	testCert1PEM = `-----BEGIN CERTIFICATE-----
+MIIEujCCAqKgAwIBAgIUE88us8tr5RRFX4RlooTtDDKao5owDQYJKoZIhvcNAQEN
+BQAwZDELMAkGA1UEBhMCVVMxKDAmBgNVBAsTH0Ryb3Bzb25kZSBDZXJ0aWZpY2F0
+ZSBBdXRob3JpdHkxFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xEzARBgNVBAgTCkNh
+bGlmb3JuaWEwHhcNMTcwMzIyMjEyNDAwWhcNMTgwMzIyMjEyNDAwWjA7MQswCQYD
+VQQGEwJVUzEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEUMBIGA1UEChMLRXhhbXBs
+ZSBPcmcwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDS8xbhnhoS9S8h
+fOoyS5UEpRa/qxqe8+CrQ/hlLmND3p9igSaMpmDzz6rhgadPSOAhU4eNkuXU+0gL
+c2qUny8TMZllS3bUzEVydRerDlz4ILsm0Pm/vvvOQxg+wAidKTpq6Mt9TjoXhqZW
+FyZzYArGecIQhofl8Z0aHhBQx3vSLCl6i+5FdBHLbrE6WKSo5nWN+lImOVBOUDoe
+KQvp9q3pX1WSzB02IEymBlMUfYuPx/Ak7q/ipgEcgQ9EkUQBR5G1fuuNzW/1WT8b
+RdduT7quEOEOTB672g4zY+DG+oo3UjgvZNSkxS9MuAHD/vC0quTKSWYqOUFsW4wO
+w+ymWO3dAgMBAAGjgYwwgYkwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsG
+AQUFBwMBMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFDg3gWdPbhl4INGDMdU/RCig
+1PrXMB8GA1UdIwQYMBaAFJs7c+/33EDkoip7EOnUrU1dDOw9MBQGA1UdEQQNMAuC
+CWxvY2FsaG9zdDANBgkqhkiG9w0BAQ0FAAOCAgEA3aqTKWrTgD3cZVuBTSz7nWRG
+k5LyVYA1wlAD1o/msPwtO1eJ/doSc+gTUyzIYoUD3wyAkTrA3UJosYiY6BYdJvsh
+AC5B/Kr+qwUjqqiE8ejPW/UzPjJldSa1zrhOMPDVDjnD+GMm9hLtxB7Mw0EWM3jn
++noiPjz6RFsbo4jhZigWrHmR1FKBoCWKEAJEzE0k5n0RljzyCk2nH6jfE1tHLaoe
+njJ6XVu3RpW9RBJJcIyfyprhrG96ch8eet0VjV3Dn746sTKYY4yDMnvTc51aXc88
+CeV6RxiqYObVbfyH8jX5v3rdJUA5FTTQU1IXx8Lt80L12Zhh+NqODlqJnnKVFAen
+KpGINr31d0x2QE5C4uhb03OUgcQDT9pOu/VyLqZo7HUPZ/0HCUhPyvZrdiCAQCkQ
+zjdxJ7iTVJibIjXjblURGsZnJ0TX1XdGcMOzQHsguNpZcDCE5lri+MlMX5Q7UVc8
+2AOP0tNzvDb/dtaKJOYHC5vF+A8mC7ypoWqIPRpgl4Q1fNor92tlAXv+EbUQ+X4s
+5IsbInK07y3bWprTUXCl9h2C3ZvZpnTDOhcwA2LppN7HRa0z86yrxMtTKXrRwzp7
+cykDEvBNRzSMW4/JLLxWXX8xkgyof0FLOvKn6Vpa8yj3PO3LKPDYKXkMzMkyquAA
+XHXWOlG/EIvvGpRRLGA=
+-----END CERTIFICATE-----`
+	testCert1X509 *x509.Certificate
+	testCert1     *certdb.Certificate
+	release       = &certdb.Release{
+		Bundle:     "ca",
+		Version:    "2017.3.0",
+		ReleasedAt: 1490827656,
+	}
+)
+
+func mustParseCertificate(in string) *x509.Certificate {
+	p, rest := pem.Decode([]byte(in))
+	if len(rest) != 0 || p == nil {
+		panic("couldn't parse certificate")
+	}
+
+	if p.Type != "CERTIFICATE" {
+		panic("invalid certificate")
+	}
+
+	cert, err := x509.ParseCertificate(p.Bytes)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return cert
+}
+
+func init() {
+	testCert1X509 = mustParseCertificate(testCert1PEM)
+	testCert1 = certdb.NewCertificate(testCert1X509)
+}
+
+func TestWriteTestCert1(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	columns := []string{"release"}
+	mock.ExpectBegin()
+	mock.ExpectQuery("SELECT (.+) FROM roots (.+)").
+		WithArgs(testCert1.SKI, testCert1.Serial).
+		WillReturnRows(sqlmock.NewRows(columns).AddRow(release.Version))
+	mock.ExpectQuery("SELECT (.+) FROM intermediates (.+)").
+		WithArgs(testCert1.SKI, testCert1.Serial).
+		WillReturnRows(sqlmock.NewRows(columns))
+	mock.ExpectQuery("SELECT (.+) FROM root_releases (.+)").
+		WithArgs(release.Version).
+		WillReturnRows(sqlmock.NewRows(columns).AddRow(release.ReleasedAt))
+	mock.ExpectCommit()
+
+	buf := &bytes.Buffer{}
+	err = WriteCertificateInformation(buf, db, testCert1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = mock.ExpectationsWereMet()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `Subject: /C=US/O=Example Org/L=San Francisco
+Issuer: /C=US/OU=Dropsonde Certificate Authority/L=San Francisco/ST=California
+	Not Before: 2017-03-22T21:24:00+0000
+	Not After: 2018-03-22T21:24:00+0000
+Releases:
+	- 2017.3.0 ca (2017-03-29T15:47:36-0700)`
+	out := strings.TrimSpace(buf.String())
+
+	if out != expected {
+		t.Fatalf(`certificate information wrote unexpected information:
+expected:
+%s
+
+have:
+%s
+`, expected, out)
+	}
+}

--- a/info/util.go
+++ b/info/util.go
@@ -1,0 +1,46 @@
+package info
+
+import (
+	"crypto/x509/pkix"
+	"fmt"
+	"strings"
+)
+
+func displayName(name pkix.Name) string {
+	var ns []string
+
+	if name.CommonName != "" {
+		ns = append(ns, name.CommonName)
+	}
+
+	for i := range name.Country {
+		ns = append(ns, fmt.Sprintf("C=%s", name.Country[i]))
+	}
+
+	for i := range name.Organization {
+		ns = append(ns, fmt.Sprintf("O=%s", name.Organization[i]))
+	}
+
+	for i := range name.OrganizationalUnit {
+		ns = append(ns, fmt.Sprintf("OU=%s", name.OrganizationalUnit[i]))
+	}
+
+	for i := range name.Locality {
+		ns = append(ns, fmt.Sprintf("L=%s", name.Locality[i]))
+	}
+
+	for i := range name.Province {
+		ns = append(ns, fmt.Sprintf("ST=%s", name.Province[i]))
+	}
+
+	if len(ns) > 0 {
+		return "/" + strings.Join(ns, "/")
+	}
+
+	return "*** no subject information ***"
+}
+
+var (
+	dateFormat = "2006-01-02T15:04:05-0700"
+	showHash   bool // if true, print a SHA256 hash of the certificate's Raw field
+)


### PR DESCRIPTION
This displays the certificate's subject and issuer information,
the not before and not after fields, and any releases the certificate is
in.