### PR TITLE
Add search subcommand.

### DIFF
--- a/cli/search.go
+++ b/cli/search.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	"github.com/cloudflare/cfssl_trust/info"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var searchCmd = &cobra.Command{
+	Use:   "search",
+	Short: "Search for certificates.",
+	Long: `
+Search for certificates that match a set of search terms. Search terms
+have the form type:regexp, e.g. ski:01234567. The supported types are:
+
+	- ski
+	- aki
+	- subject
+	- issuer
+	- release
+	- bundle
+
+Multiple search terms are supported; for example "ski:1234567 issuer:Example".
+
+The subject and example use the string form of the issuer as produced
+by the info command; for example, a certificate with 'Example' in the
+subject's organisation field can be search for using
+
+	subject:O=Example
+
+The support regular expression syntax is the RE2 syntax used by the Go
+programming language described at https://golang.org/s/re2syntax.
+`,
+	Run: search,
+}
+
+func init() {
+	RootCmd.AddCommand(searchCmd)
+}
+
+func search(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		os.Exit(0)
+	}
+
+	dbPath := viper.GetString("database.path")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] %s\n", err)
+		os.Exit(1)
+	}
+
+	results, err := info.Query(db, args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[!] %s\n", err)
+		os.Exit(1)
+	}
+
+	for _, cert := range results {
+		err = info.WriteCertificateMetadata(os.Stdout, cert)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[!] %s\n", err)
+			os.Exit(1)
+		}
+	}
+}

--- a/common/subject.go
+++ b/common/subject.go
@@ -1,4 +1,4 @@
-package info
+package common
 
 import (
 	"crypto/x509/pkix"
@@ -6,7 +6,9 @@ import (
 	"strings"
 )
 
-func displayName(name pkix.Name) string {
+const DateFormat = "2006-01-02T15:04:05-0700"
+
+func NameToString(name pkix.Name) string {
 	var ns []string
 
 	if name.CommonName != "" {
@@ -39,8 +41,3 @@ func displayName(name pkix.Name) string {
 
 	return "*** no subject information ***"
 }
-
-var (
-	dateFormat = "2006-01-02T15:04:05-0700"
-	showHash   bool // if true, print a SHA256 hash of the certificate's Raw field
-)

--- a/info/info.go
+++ b/info/info.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"time"
 
+	"github.com/cloudflare/cfssl_trust/common"
 	"github.com/cloudflare/cfssl_trust/model/certdb"
 )
 
@@ -16,9 +18,10 @@ func writeBasicInformation(w io.Writer, cert *x509.Certificate) error {
 Issuer: %s
 	Not Before: %s
 	Not After: %s
-`, displayName(cert.Subject), displayName(cert.Issuer),
-		cert.NotBefore.Format(dateFormat),
-		cert.NotAfter.Format(dateFormat),
+`, common.NameToString(cert.Subject),
+		common.NameToString(cert.Issuer),
+		cert.NotBefore.Format(common.DateFormat),
+		cert.NotAfter.Format(common.DateFormat),
 	)
 	return err
 }
@@ -37,7 +40,7 @@ func writeCertificateReleases(w io.Writer, tx *sql.Tx, cert *certdb.Certificate)
 	for _, rel := range releases {
 		_, err = fmt.Fprintf(w, "\t- %s %s (%s)\n",
 			rel.Version, rel.Bundle,
-			time.Unix(rel.ReleasedAt, 0).Format(dateFormat))
+			time.Unix(rel.ReleasedAt, 0).Format(common.DateFormat))
 		if err != nil {
 			break
 		}
@@ -65,4 +68,65 @@ func WriteCertificateInformation(w io.Writer, db *sql.DB, cert *certdb.Certifica
 	}
 
 	return nil
+}
+
+// CertificateMetadata pairs the AKI, SKI, and Serial Number with
+// string versions of the subject and issuer fields.
+type CertificateMetadata struct {
+	SKI, AKI string
+	Serial   *big.Int
+	Subject  string
+	Issuer   string
+	Releases []*certdb.Release
+	cert     *certdb.Certificate
+}
+
+func LoadCertificateMetadata(tx *sql.Tx, cert *certdb.Certificate) (*CertificateMetadata, error) {
+	x509Cert := cert.X509()
+	cm := &CertificateMetadata{
+		SKI:     cert.SKI,
+		AKI:     cert.AKI,
+		Serial:  x509Cert.SerialNumber,
+		Subject: common.NameToString(x509Cert.Subject),
+		Issuer:  common.NameToString(x509Cert.Issuer),
+		cert:    cert,
+	}
+
+	var err error
+	cm.Releases, err = cert.Releases(tx)
+	return cm, err
+}
+
+// WriteCertificateMetadata pretty prints the certificate metadata to
+// the given io.Writer.
+func WriteCertificateMetadata(w io.Writer, cert *CertificateMetadata) error {
+	x509Cert := cert.cert.X509()
+	_, err := fmt.Fprintf(w, `Subject: %s
+Issuer: %s
+	Not Before: %s
+	Not After: %s
+`, (cert.Subject),
+		(cert.Issuer),
+		x509Cert.NotBefore.Format(common.DateFormat),
+		x509Cert.NotAfter.Format(common.DateFormat),
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(w, "\tReleases:\n")
+	if err != nil {
+		return err
+	}
+
+	for _, rel := range cert.Releases {
+		_, err = fmt.Fprintf(w, "\t\t- %s %s (%s)\n",
+			rel.Version, rel.Bundle,
+			time.Unix(rel.ReleasedAt, 0).Format(common.DateFormat))
+		if err != nil {
+			break
+		}
+	}
+
+	return err
 }

--- a/info/search.go
+++ b/info/search.go
@@ -1,0 +1,184 @@
+package info
+
+import (
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/cloudflare/cfssl_trust/model/certdb"
+)
+
+// A CertificateFilter is a predicate that returns true if the
+// certificate matches some predicate.
+type CertificateFilter func(*CertificateMetadata) bool
+
+func filter(certs []*CertificateMetadata, pred CertificateFilter) []*CertificateMetadata {
+	filtered := []*CertificateMetadata{}
+	for i := range certs {
+		if pred(certs[i]) {
+			filtered = append(filtered, certs[i])
+		}
+	}
+	return filtered
+}
+
+// filterCertificates applies the filters to the list of certificates,
+// returning only those certificates that match all the filters.
+func filterCertificates(certs []*CertificateMetadata, filters []CertificateFilter) []*CertificateMetadata {
+	filtered := certs
+	for _, f := range filters {
+		filtered = filter(filtered, f)
+	}
+	return filtered
+}
+
+// FilterBySKI is a CertificateFilter that returns true if the SKI in
+// a certificate matches the regular expression passed in.
+func FilterBySKI(ski string) (CertificateFilter, error) {
+	skiFilter, err := regexp.Compile(ski)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(cm *CertificateMetadata) bool {
+		return skiFilter.MatchString(cm.SKI)
+	}, nil
+}
+
+// FilterByAKI is a CertificateFilter that returns true if the AKI in
+// a certificate matches the regular expression passed in.
+func FilterByAKI(aki string) (CertificateFilter, error) {
+	akiFilter, err := regexp.Compile(aki)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(cm *CertificateMetadata) bool {
+		return akiFilter.MatchString(cm.AKI)
+	}, nil
+}
+
+// FilterBySubject is a CertificateFilter that returns true if the
+// Subject in a certificate matches the regular expression passed in.
+func FilterBySubject(subj string) (CertificateFilter, error) {
+	subjFilter, err := regexp.Compile(subj)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(cm *CertificateMetadata) bool {
+		return subjFilter.MatchString(cm.Subject)
+	}, nil
+}
+
+// FilterByIssuer is a CertificateFilter that returns true if the
+// Issuer in a certificate matches the regular expression passed in.
+func FilterByIssuer(iss string) (CertificateFilter, error) {
+	issFilter, err := regexp.Compile(iss)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(cm *CertificateMetadata) bool {
+		return issFilter.MatchString(cm.Issuer)
+	}, nil
+}
+
+// FilterByRelease is a CertificateFilter that returns true if the
+// release version matches the regular expression passed in.
+func FilterByRelease(version string) (CertificateFilter, error) {
+	verFilter, err := regexp.Compile(version)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(cm *CertificateMetadata) bool {
+		for _, rel := range cm.Releases {
+			if verFilter.MatchString(rel.Version) {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+// FilterByBundle is a CertificateFilter that returns true if the
+// release bundle matches the regular expression passed in.
+func FilterByBundle(bundle string) (CertificateFilter, error) {
+	bundleFilter, err := regexp.Compile(bundle)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(cm *CertificateMetadata) bool {
+		for _, rel := range cm.Releases {
+			if bundleFilter.MatchString(rel.Bundle) {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+var filters = map[string]func(string) (CertificateFilter, error){
+	"ski":     FilterBySKI,
+	"aki":     FilterByAKI,
+	"subject": FilterBySubject,
+	"issuer":  FilterByIssuer,
+	"release": FilterByRelease,
+	"bundle":  FilterByBundle,
+}
+
+// ParseQuery attempts to parse a query in the form "type:regexp",
+// returning a filter if successful.
+func ParseQuery(query string) (CertificateFilter, error) {
+	parts := strings.SplitN(query, ":", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("info: expected a query in the form type:regexp")
+	}
+
+	// parts[0]: type
+	// parts[1]: regexp
+	f, ok := filters[parts[0]]
+	if !ok {
+		return nil, errors.New("info: unknown filter type " + parts[0])
+	}
+
+	return f(parts[1])
+}
+
+// Query searches the database for all certificates matching the search terms.
+func Query(db *sql.DB, terms []string) ([]*CertificateMetadata, error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	certs, err := certdb.AllCertificates(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]*CertificateMetadata, len(certs))
+	for i := range certs {
+		results[i], err = LoadCertificateMetadata(tx, certs[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	filters := make([]CertificateFilter, 0, len(terms))
+	for _, term := range terms {
+		f, err := ParseQuery(term)
+		if err != nil {
+			return nil, err
+		}
+
+		filters = append(filters, f)
+	}
+
+	err = tx.Commit()
+	return filterCertificates(results, filters), err
+}

--- a/model/certdb/certificate.go
+++ b/model/certdb/certificate.go
@@ -70,6 +70,33 @@ SELECT aki, serial, not_before, not_after, raw
 	return certificates, nil
 }
 
+// AllCertificates loads all the certificates in the database.
+func AllCertificates(tx *sql.Tx) ([]*Certificate, error) {
+	rows, err := tx.Query("SELECT * FROM certificates")
+	if err != nil {
+		return nil, err
+	}
+
+	var certificates []*Certificate
+	for rows.Next() {
+		cert := &Certificate{}
+		err = rows.Scan(&cert.SKI, &cert.AKI, &cert.Serial, &cert.NotBefore,
+			&cert.NotAfter, &cert.Raw)
+		if err != nil {
+			return nil, err
+		}
+
+		cert.cert, err = x509.ParseCertificate(cert.Raw)
+		if err != nil {
+			return nil, err
+		}
+
+		certificates = append(certificates, cert)
+	}
+
+	return certificates, err
+}
+
 // Table provides an interface for mapping a struct to a table in the
 // database.
 type Table interface {

--- a/model/certdb/certificate_test.go
+++ b/model/certdb/certificate_test.go
@@ -535,3 +535,31 @@ func TestFindCertificateBySKI(t *testing.T) {
 			certs[0].cert.SerialNumber, expectedSerial)
 	}
 }
+
+func TestAllCertificates(t *testing.T) {
+	tx, err := testDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		switch err {
+		case nil:
+			if err = tx.Commit(); err != nil {
+				t.Fatal(err)
+			}
+		default:
+			tx.Rollback()
+			t.Fatal("database wauts rolled back")
+		}
+	}()
+
+	certs, err := AllCertificates(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(certs) != 3 {
+		t.Fatal("expected 3 certificates from AllCertificates, but have", len(certs))
+	}
+}


### PR DESCRIPTION
The search subcommand allows search for certificates using search
terms. For example, calling

  cfssl-trust search issuer:O=Example

will return a list of all certificates where the subject has an
Organization starting with Example.

The help text for this command has more information.